### PR TITLE
:bug: fix(api): make all creation endpoints return 201 Created

### DIFF
--- a/bullsquid/customer_wallet/user_lookups/views.py
+++ b/bullsquid/customer_wallet/user_lookups/views.py
@@ -25,7 +25,7 @@ def make_user_lookup_response(result: db.UserLookupResult) -> UserLookupResponse
     )
 
 
-@router.get("")
+@router.get("", response_model=list[UserLookupResponse])
 async def list_user_lookups(
     user: str = Header(),
     n: int = Query(default=5),

--- a/bullsquid/merchant_data/identifiers/views.py
+++ b/bullsquid/merchant_data/identifiers/views.py
@@ -67,7 +67,7 @@ async def get_identifier_details(
     return create_identifier_response(mid)
 
 
-@router.post("")
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=IdentifierResponse)
 async def create_identifier(
     plan_ref: UUID,
     merchant_ref: UUID,
@@ -104,7 +104,11 @@ async def create_identifier(
     return create_identifier_response(identifier)
 
 
-@router.post("/deletion", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/deletion",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=IdentifierDeletionListResponse,
+)
 async def delete_identifiers(
     plan_ref: UUID, merchant_ref: UUID, identifier_refs: list[UUID]
 ) -> IdentifierDeletionListResponse:

--- a/bullsquid/merchant_data/merchants/views.py
+++ b/bullsquid/merchant_data/merchants/views.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
 
 from bullsquid.api.errors import ResourceNotFoundError, UniqueError
 from bullsquid.db import NoSuchRecord, field_is_unique
@@ -100,7 +100,11 @@ async def get_merchant(plan_ref: UUID, merchant_ref: UUID) -> MerchantDetailResp
     return await create_merchant_detail_response(merchant, plan)
 
 
-@router.post("", response_model=MerchantOverviewResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=MerchantOverviewResponse,
+)
 async def create_merchant(plan_ref: UUID, merchant_data: CreateMerchantRequest) -> dict:
     """Add a new merchant to a plan."""
     try:

--- a/bullsquid/merchant_data/plans/views.py
+++ b/bullsquid/merchant_data/plans/views.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
 
 from bullsquid.api.errors import APIMultiError, ResourceNotFoundError, UniqueError
 from bullsquid.db import NoSuchRecord, field_is_unique
@@ -61,7 +61,7 @@ async def list_plans() -> list[PlanResponse]:
     ]
 
 
-@router.post("", response_model=PlanResponse)
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=PlanResponse)
 async def create_plan(plan_data: CreatePlanRequest) -> PlanResponse:
     """Create a new plan."""
     plan_data = plan_data.dict()

--- a/bullsquid/merchant_data/primary_mids/views.py
+++ b/bullsquid/merchant_data/primary_mids/views.py
@@ -64,7 +64,7 @@ async def list_primary_mids(
     return await create_primary_mid_list_response(mids)
 
 
-@router.post("", response_model=PrimaryMIDResponse)
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=PrimaryMIDResponse)
 async def create_primary_mid(
     plan_ref: UUID, merchant_ref: UUID, mid_data: CreatePrimaryMIDRequest
 ) -> PrimaryMIDResponse:
@@ -87,7 +87,11 @@ async def create_primary_mid(
     return await create_primary_mid_response(mid)
 
 
-@router.post("/deletion", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/deletion",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=PrimaryMIDDeletionListResponse,
+)
 async def delete_primary_mids(
     plan_ref: UUID, merchant_ref: UUID, mid_refs: list[UUID]
 ) -> PrimaryMIDDeletionListResponse:

--- a/bullsquid/merchant_data/secondary_mids/views.py
+++ b/bullsquid/merchant_data/secondary_mids/views.py
@@ -71,7 +71,11 @@ async def get_secondary_mid_details(
     return create_secondary_mid_response(mid)
 
 
-@router.post("", response_model=SecondaryMIDResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=SecondaryMIDResponse,
+)
 async def create_secondary_mid(
     plan_ref: UUID,
     merchant_ref: UUID,
@@ -110,7 +114,11 @@ async def create_secondary_mid(
     return create_secondary_mid_response(secondary_mid)
 
 
-@router.post("/deletion", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/deletion",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_model=SecondaryMIDDeletionListResponse,
+)
 async def delete_secondary_mids(
     plan_ref: UUID, merchant_ref: UUID, secondary_mid_refs: list[UUID]
 ) -> SecondaryMIDDeletionListResponse:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -14,7 +14,7 @@ def _(
     auth_header: dict = auth_header,
 ) -> None:
     resp = test_client.get("/api/v1/plans", headers=auth_header)
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
 
 
 @test("invalid auth header format returns 401 unauthorized")

--- a/tests/merchant_data/identifiers/test_views.py
+++ b/tests/merchant_data/identifiers/test_views.py
@@ -74,7 +74,7 @@ async def _(
         headers=auth_header,
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await identifier_to_json(identifier)]
 
 
@@ -104,7 +104,7 @@ async def _(
         headers=auth_header,
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await identifier_to_json(identifier)]
 
 
@@ -129,7 +129,7 @@ async def _(
 
     expected = await Identifier.objects().where(Identifier.merchant == merchants[0])
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
         await identifier_to_json(identifier) for identifier in expected
     ]
@@ -250,7 +250,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     identifier_ref = resp.json()["identifier_ref"]
 
@@ -284,7 +284,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     identifier_ref = resp.json()["identifier_ref"]
 

--- a/tests/merchant_data/merchants/test_views.py
+++ b/tests/merchant_data/merchants/test_views.py
@@ -2,6 +2,7 @@
 
 from uuid import uuid4
 
+from fastapi import status
 from fastapi.testclient import TestClient
 from ward import skip, test
 
@@ -84,7 +85,7 @@ async def _(
     ]
 
     resp = test_client.get(f"/api/v1/plans/{plan.pk}/merchants", headers=auth_header)
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
         merchant_list_to_json(merchant, payment_schemes) for merchant in merchants
     ]
@@ -111,7 +112,7 @@ async def _(
     resp = test_client.get(
         f"/api/v1/plans/{plan.pk}/merchants/{merchant.pk}", headers=auth_header
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == await merchant_detail_to_json(merchant)
 
 
@@ -156,7 +157,7 @@ async def _(
             "location_label": merchant.location_label,
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
     merchant = await get_merchant(resp.json()["merchant_ref"], plan_ref=plan.pk)
     assert resp.json() == merchant_list_to_json(merchant, payment_schemes)
 
@@ -256,7 +257,7 @@ async def _(
             "icon_url": new_details.icon_url,
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     merchant = await get_merchant(merchant.pk, plan_ref=merchant.plan)
     assert resp.json() == merchant_list_to_json(merchant, payment_schemes)
     assert merchant.name == new_details.name

--- a/tests/merchant_data/plans/test_views.py
+++ b/tests/merchant_data/plans/test_views.py
@@ -3,6 +3,7 @@
 import random
 from uuid import uuid4
 
+from fastapi import status
 from fastapi.testclient import TestClient
 from ward import test
 
@@ -60,7 +61,7 @@ async def _(
     payment_schemes: list[PaymentScheme] = payment_schemes,
 ) -> None:
     resp = test_client.get("/api/v1/plans", headers=auth_header)
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await plan_to_json(plan, payment_schemes) for plan in plans]
 
 
@@ -76,7 +77,7 @@ async def _(
             await merchant_factory(plan=plan)
 
     resp = test_client.get("/api/v1/plans", headers=auth_header)
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await plan_to_json(plan, payment_schemes) for plan in plans]
 
 
@@ -97,7 +98,7 @@ async def _(
             "icon_url": plan.icon_url,
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
     plan = await get_plan(resp.json()["plan_ref"])
     assert resp.json() == await plan_to_json(plan, payment_schemes)
 
@@ -218,7 +219,7 @@ async def _(
             "icon_url": new_details.icon_url,
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     plan = await get_plan(plan.pk)
     assert resp.json() == await plan_to_json(plan, payment_schemes)
     assert plan.name == new_details.name

--- a/tests/merchant_data/primary_mids/test_views.py
+++ b/tests/merchant_data/primary_mids/test_views.py
@@ -74,7 +74,7 @@ async def _(
         f"/api/v1/plans/{plan_ref}/merchants/{merchant_ref}/mids", headers=auth_header
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"mids": [await primary_mid_to_json(primary_mid)]}
 
 
@@ -103,7 +103,7 @@ async def _(
         f"/api/v1/plans/{plan_ref}/merchants/{merchant_ref}/mids", headers=auth_header
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {"mids": [await primary_mid_to_json(primary_mid)]}
 
 
@@ -128,7 +128,7 @@ async def _(
 
     expected = await PrimaryMID.objects().where(PrimaryMID.merchant == merchants[0])
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == {
         "mids": [await primary_mid_to_json(primary_mid) for primary_mid in expected]
     }
@@ -182,7 +182,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     mid_ref = resp.json()["mid_ref"]
 
@@ -216,7 +216,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     mid_ref = resp.json()["mid_ref"]
 
@@ -249,7 +249,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     expected = (
         await PrimaryMID.objects()

--- a/tests/merchant_data/secondary_mids/test_views.py
+++ b/tests/merchant_data/secondary_mids/test_views.py
@@ -78,7 +78,7 @@ async def _(
         headers=auth_header,
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await secondary_mid_to_json(secondary_mid)]
 
 
@@ -110,7 +110,7 @@ async def _(
         headers=auth_header,
     )
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [await secondary_mid_to_json(secondary_mid)]
 
 
@@ -135,7 +135,7 @@ async def _(
 
     expected = await SecondaryMID.objects().where(SecondaryMID.merchant == merchants[0])
 
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_200_OK
     assert resp.json() == [
         await secondary_mid_to_json(secondary_mid) for secondary_mid in expected
     ]
@@ -257,7 +257,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     mid_ref = resp.json()["secondary_mid_ref"]
     expected = await SecondaryMID.objects().where(SecondaryMID.pk == mid_ref).first()
@@ -292,7 +292,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     mid_ref = resp.json()["secondary_mid_ref"]
 
@@ -326,7 +326,7 @@ async def _(
             },
         },
     )
-    assert resp.ok, resp.json()
+    assert resp.status_code == status.HTTP_201_CREATED
 
     expected = (
         await SecondaryMID.objects()


### PR DESCRIPTION
i've added 201 status codes to all create_* endpoints that needed it.

i also took the opportunity to make the tests more specific in which status codes they were looking for, as well as documenting the response model for each endpoint explicitly.