### PR TITLE
:bug: fix crash when excluding an unlinked secondary mid

### DIFF
--- a/bullsquid/merchant_data/locations/db.py
+++ b/bullsquid/merchant_data/locations/db.py
@@ -99,7 +99,8 @@ async def list_locations(
             .where(LocationSecondaryMIDLink.secondary_mid == exclude_secondary_mid)
             .output(as_list=True)
         )
-        query = query.where(Location.pk.not_in(linked_location_pks))
+        if linked_location_pks:
+            query = query.where(Location.pk.not_in(linked_location_pks))
 
     return await paginate(
         query,


### PR DESCRIPTION
resolves this error:
https://sentry.io/organizations/bink/issues/3554975171/events/b803b85deaca48f89126c11376e87606